### PR TITLE
Refactor Responsible

### DIFF
--- a/healthcheck-api/src/main/java/com/storebrand/healthcheck/Axis.java
+++ b/healthcheck-api/src/main/java/com/storebrand/healthcheck/Axis.java
@@ -202,7 +202,7 @@ public enum Axis {
 
     /**
      * Convenience method to create an array of Axis'es - simply to avoid the somewhat verbose <code>new Axis[] {axis1,
-     * axis2}</code> code in the {@link CheckSpecification#check(Responsible, Axis[], Function)
+     * axis2}</code> code in the {@link CheckSpecification#check(CharSequence, Axis[], Function)
      * CheckSpecification.check(responsible, {axes}, lambda)} invocation, instead being able to use the slightly
      * prettier <code>Axis.of(axis1, axis2)</code>.
      *

--- a/healthcheck-api/src/main/java/com/storebrand/healthcheck/CheckSpecification.java
+++ b/healthcheck-api/src/main/java/com/storebrand/healthcheck/CheckSpecification.java
@@ -108,7 +108,23 @@ public interface CheckSpecification {
      * Create an actual check inside this health check that checks an aspect of the system, and returns a set of
      * predefined axes that are either active or not, indicating a fault or no fault.
      *
-     * @param responsible
+     * @param responsibleTeams
+     *         the team(s) responsible for first looking into this check if it is faulty.
+     * @param axes
+     *         the axes that this status may trigger, worst case. You may use {@link Axis#of(Axis...)} to create this
+     *         array.
+     * @param method
+     *         the lambda/method that performs the actual check.
+     * @return {@link CheckSpecification} so we can chain commands in a builder pattern way.
+     */
+    CheckSpecification check(CharSequence responsibleTeams[], Axis[] axes, Function<CheckContext, CheckResult> method);
+
+    /**
+     * Convenience variant of {@link #check(CharSequence[], Axis[], Function)} if you only have a single responsible
+     * team. Create an actual check inside this health check that checks an aspect of the system, and returns a set of
+     * predefined axes that are either active or not, indicating a fault or no fault.
+     *
+     * @param responsibleTeam
      *         the team responsible for first looking into this check if it is faulty.
      * @param axes
      *         the axes that this status may trigger, worst case. You may use {@link Axis#of(Axis...)} to create this
@@ -117,23 +133,62 @@ public interface CheckSpecification {
      *         the lambda/method that performs the actual check.
      * @return {@link CheckSpecification} so we can chain commands in a builder pattern way.
      */
-    CheckSpecification check(Responsible responsible, Axis[] axes, Function<CheckContext, CheckResult> method);
+    default CheckSpecification check(CharSequence responsibleTeam, Axis[] axes,
+            Function<CheckContext, CheckResult> method) {
+        return check(Responsible.teams(responsibleTeam), axes, method);
+    }
+
+    /**
+     * Only supplied for backwards compatibility. See {@link #check(Responsible, Axis[], Function)} for details.
+     */
+    default CheckSpecification check(Responsible responsible, Axis[] axes, Function<CheckContext, CheckResult> method) {
+        return check((CharSequence) responsible, axes, method);
+    }
 
     /**
      * Convenience variant of {@link #check(Responsible, Axis[], Function)} if you only have a single axis. Create an
      * actual check inside this health check that checks an aspect of the system, and returns a set of predefined axes
      * that are either active or not, indicating a fault or no fault.
      *
-     * @param responsible
+     * @param responsibleTeams
      *         the team responsible for first looking into this check if it is faulty.
      * @param singleAxis
      *         the single axis that this status may trigger, worst case. If you need multiple axis, employ the {@link
-     *         #check(Responsible, Axis[], Function)}.
+     *         #check(CharSequence, Axis[], Function)}.
      * @param method
      *         the lambda/method that performs the actual check.
      * @return {@link CheckSpecification} so we can chain commands in a builder pattern way.
      */
-    CheckSpecification check(Responsible responsible, Axis singleAxis, Function<CheckContext, CheckResult> method);
+    default CheckSpecification check(CharSequence[] responsibleTeams, Axis singleAxis, Function<CheckContext,
+            CheckResult> method) {
+        return check(responsibleTeams, Axis.of(singleAxis), method);
+    }
+
+    /**
+     * Convenience variant of {@link #check(CharSequence[], Axis[], Function)} if you only have a single responsible
+     * team and a single axis. Create an actual check inside this health check that checks an aspect of the system, and
+     * returns a set of predefined axes that are either active or not, indicating a fault or no fault.
+     *
+     * @param responsibleTeam
+     *         the team responsible for first looking into this check if it is faulty.
+     * @param singleAxis
+     *         the single axis that this status may trigger, worst case. If you need multiple axis, employ the {@link
+     *         #check(CharSequence, Axis[], Function)}.
+     * @param method
+     *         the lambda/method that performs the actual check.
+     * @return {@link CheckSpecification} so we can chain commands in a builder pattern way.
+     */
+    default CheckSpecification check(CharSequence responsibleTeam, Axis singleAxis, Function<CheckContext,
+            CheckResult> method) {
+        return check(Responsible.teams(responsibleTeam), Axis.of(singleAxis), method);
+    }
+
+    /**
+     * Only supplied for backwards compatibility. See {@link #check(Responsible, Axis, Function)} for details.
+     */
+    default CheckSpecification check(Responsible responsible, Axis singleAxis, Function<CheckContext, CheckResult> method) {
+        return check((CharSequence) responsible, singleAxis, method);
+    }
 
     /**
      * Pass structured data along with the health check result, so a machine can parse and do something with this. Use
@@ -188,7 +243,7 @@ public interface CheckSpecification {
     }
 
     /**
-     * The shared context interface that is passed to actual {@link CheckSpecification#check(Responsible, Axis[],
+     * The shared context interface that is passed to actual {@link CheckSpecification#check(CharSequence, Axis[],
      * Function)} methods are more complex, as that allows for actually adding more text and links, and also it contains
      * the methods for creating a {@link CheckResult}. It is also possible to put data into the shared context for
      * consumption by later steps in the health check.

--- a/healthcheck-api/src/main/java/com/storebrand/healthcheck/HealthCheckReportDto.java
+++ b/healthcheck-api/src/main/java/com/storebrand/healthcheck/HealthCheckReportDto.java
@@ -20,6 +20,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -155,8 +156,16 @@ public class HealthCheckReportDto {
         public Optional<ThrowableHolderDto> exception = Optional.empty();
         /** An optional link that we may include for easy navigation to relevant pages */
         public Optional<LinkDto> link = Optional.empty();
-        /** If this check triggers any axes this is the team responsible for looking into the issue */
-        public Optional<Responsible> responsible = Optional.empty();
+        /**
+         * DEPRECATED - use responsibleTeams list instead. This will only include the first team in the team list, if
+         * there are multiple responsible teams.
+         * <p>
+         * If this check triggers any axes this is the team responsible for looking into the issue. If there are
+         * multiple teams responsible this will show the first one in the list.
+         */
+        public Optional<String> responsible = Optional.empty();
+        /** If this check triggers any axes these are the teams responsible for looking into the issue */
+        public List<String> responsibleTeams = Collections.emptyList();
     }
 
     /**

--- a/healthcheck-api/src/main/java/com/storebrand/healthcheck/Responsible.java
+++ b/healthcheck-api/src/main/java/com/storebrand/healthcheck/Responsible.java
@@ -16,14 +16,18 @@
 
 package com.storebrand.healthcheck;
 
+import java.util.function.Function;
+
 /**
- * Defines the "team" that should be the first to inspect a status check that fails.
+ * Defines the "team" that should be the first to inspect a status check that fails. Note that this enum implements
+ * {@link CharSequence}, and it is possible to define your own teams. The API accepts any {@link CharSequence} as
+ * responsible.
  *
  * @author Kristian Hiim, 2021-2022 kristian@hiim.no
  * @author Endre Stølsvik, 2021-2022 endre@stolsvik.com
  * @author Hallvard Nygård, Knut Saua Mathiesen, Endre Stølsvik, Dag Lennart Bertelsen, Kevin Mc Tiernan 2014-2021: former ServerStatus-solution and discussions/input
  */
-public enum Responsible {
+public enum Responsible implements CharSequence {
     /**
      * Probably a code problem, or corner case, which developers needs to look into.
      */
@@ -46,5 +50,34 @@ public enum Responsible {
      * <p/>
      * https://en.wikipedia.org/wiki/Front_office
      */
-    FRONT_OFFICE
+    FRONT_OFFICE;
+
+    @Override
+    public int length() {
+        return name().length();
+    }
+
+    @Override
+    public char charAt(int index) {
+        return name().charAt(index);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+        return name().subSequence(start, end);
+    }
+
+    /**
+     * Convenience method to create an array of {@link CharSequence} - simply to avoid the somewhat verbose
+     * <code>new CharSequence[] {team1, team2}</code> code in the
+     * {@link CheckSpecification#check(CharSequence[], Axis[], Function) CheckSpecification.check({responsible}, {axes}, lambda)}
+     * invocation, instead being able to use the slightly prettier <code>Responsible.teams(team1, team2)</code>.
+     *
+     * @param axes
+     *         the axes to include
+     * @return the array of axes
+     */
+    public static CharSequence[] teams(CharSequence... teams) {
+        return teams;
+    }
 }

--- a/healthcheck/src/main/java/com/storebrand/healthcheck/HealthCheckRegistryImpl.java
+++ b/healthcheck/src/main/java/com/storebrand/healthcheck/HealthCheckRegistryImpl.java
@@ -596,13 +596,13 @@ public class HealthCheckRegistryImpl implements HealthCheckRegistry {
         statusDto.description = status.getDescription();
 
         AxesDto axesDto = null;
-        Responsible responsible = null;
+        List<CharSequence> responsibleTeams = null;
         Collection<EntityRefDto> affectedEntities = Collections.emptyList();
         // Check if this has status properties attached:
         if (status instanceof StatusWithAxes) {
             StatusWithAxes statusWithAxes = (StatusWithAxes) status;
             axesDto = axesToDto(statusWithAxes.getAxes());
-            responsible = statusWithAxes.getResponsible();
+            responsibleTeams = statusWithAxes.getResponsibleTeams();
             affectedEntities = statusWithAxes.getAffectedEntities()
                     .map(entities -> entities.stream().map(CheckSpecification.EntityRef::toDto).collect(toList()))
                     .orElse(null);
@@ -634,7 +634,12 @@ public class HealthCheckRegistryImpl implements HealthCheckRegistry {
         }
 
         statusDto.axes = Optional.ofNullable(axesDto);
-        statusDto.responsible = Optional.ofNullable(responsible);
+        statusDto.responsible = responsibleTeams != null && !responsibleTeams.isEmpty()
+                ? Optional.ofNullable(responsibleTeams.get(0)).map(CharSequence::toString)
+                : Optional.empty();
+        statusDto.responsibleTeams = responsibleTeams != null
+                ? responsibleTeams.stream().map(CharSequence::toString).collect(toList())
+                : Collections.emptyList();
         statusDto.affectedEntities = affectedEntities;
         statusDto.exception = Optional.ofNullable(reportException);
         statusDto.link = Optional.ofNullable(linkDto);


### PR DESCRIPTION
- make the Responsible enum implement CharSequence.
- update methods for registering checks to accept CharSequence, so it is possible to define any team.
- make it possible to set more than one team as responsible
- add responsibleTeams to the health check report DTO.