### PR TITLE
Allow excluding service info

### DIFF
--- a/healthcheck-api/src/main/java/com/storebrand/healthcheck/HealthCheckRegistry.java
+++ b/healthcheck-api/src/main/java/com/storebrand/healthcheck/HealthCheckRegistry.java
@@ -282,6 +282,7 @@ public interface HealthCheckRegistry {
     class CreateReportRequest {
         private Collection<Axis> _axes = Collections.emptyList(); // Empty -> no filtering.
         private boolean _forceFreshData = false;
+        private boolean _excludeServiceInfo = false;
         private final Set<String> _excludeChecks = new TreeSet<>();
         private final List<Predicate<RegisteredHealthCheck>> _filters = new ArrayList<>();
 
@@ -298,6 +299,16 @@ public interface HealthCheckRegistry {
          */
         public CreateReportRequest excludeChecks(Collection<String> names) {
             _excludeChecks.addAll(names);
+            return this;
+        }
+
+        /**
+         * Do not include Service information in the report. This will allow us to not calculate the field
+         * {@link HealthCheckReportDto#service}, and save some time when generating a report. This is useful if we want
+         * to only check readiness or liveness.
+         */
+        public CreateReportRequest excludeServiceInfo() {
+            _excludeServiceInfo = true;
             return this;
         }
 
@@ -338,7 +349,8 @@ public interface HealthCheckRegistry {
          */
         public static CreateReportRequest readinessStatus() {
             return new CreateReportRequest()
-                    .includeOnlyChecksWithAnyOfTheseAxes(Axis.NOT_READY);
+                    .includeOnlyChecksWithAnyOfTheseAxes(Axis.NOT_READY)
+                    .excludeServiceInfo();
         }
 
         /**
@@ -351,7 +363,8 @@ public interface HealthCheckRegistry {
          */
         public static CreateReportRequest livenessStatus() {
             return new CreateReportRequest()
-                    .includeOnlyChecksWithAnyOfTheseAxes(Axis.REQUIRES_REBOOT);
+                    .includeOnlyChecksWithAnyOfTheseAxes(Axis.REQUIRES_REBOOT)
+                    .excludeServiceInfo();
         }
 
         /**
@@ -393,6 +406,10 @@ public interface HealthCheckRegistry {
 
         public boolean shouldForceFreshData() {
             return _forceFreshData;
+        }
+
+        public boolean shouldExcludeServiceInfo() {
+            return _excludeServiceInfo;
         }
     }
 }

--- a/healthcheck-impl/src/main/java/com/storebrand/healthcheck/impl/HealthCheckRegistryImpl.java
+++ b/healthcheck-impl/src/main/java/com/storebrand/healthcheck/impl/HealthCheckRegistryImpl.java
@@ -336,7 +336,12 @@ public class HealthCheckRegistryImpl implements HealthCheckRegistry {
             throw new HealthChecksNotRunningException();
         }
 
-        HealthCheckReportDto.ServiceInfoDto serviceInfo = _serviceInfo.getServiceInfo();
+        // :: Get service info
+        // Due to the cost of calculating this, we allow the caller to exclude it. This is useful for probes that only
+        // need the readiness or liveness status.
+        HealthCheckReportDto.ServiceInfoDto serviceInfo = createReportRequest.shouldExcludeServiceInfo()
+                ? null
+                : _serviceInfo.getServiceInfo();
 
         // :: Get Statuses for from all health check runners
         List<HealthCheckResult> statuses = new ArrayList<>();

--- a/healthcheck-output/src/main/java/com/storebrand/healthcheck/output/HealthCheckTextOutput.java
+++ b/healthcheck-output/src/main/java/com/storebrand/healthcheck/output/HealthCheckTextOutput.java
@@ -76,24 +76,31 @@ public class HealthCheckTextOutput implements HealthCheckOutput {
                 dto.axes.activated.stream(),
                 dto.healthChecks.stream().map(status -> status.runStatus)));
 
-        out.println("Project name:       " + dto.service.project.name);
-        out.println("Project version:    " + dto.service.project.version);
-        out.println("Host name:          " + dto.service.host.name
-                + " (" + dto.service.host.primaryAddress + ")");
+        // Only show service info if the DTO contains this information
+        if (dto.service != null) {
+            out.println("Project name:       " + dto.service.project.name);
+            out.println("Project version:    " + dto.service.project.version);
+            out.println("Host name:          " + dto.service.host.name
+                    + " (" + dto.service.host.primaryAddress + ")");
 
-        dto.service.properties.forEach(property ->
-                out.printf("%-20s%s\n", property.displayName.orElse(property.name) + ":", property.value));
+            dto.service.properties.forEach(property ->
+                    out.printf("%-20s%s\n", property.displayName.orElse(property.name) + ":", property.value));
 
-        Instant jvmStartTime = dto.service.runningSince;
-        LocalDateTime startTime = LocalDateTime.ofInstant(jvmStartTime, ZoneId.systemDefault());
-        String startDateTime = startTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+            Instant jvmStartTime = dto.service.runningSince;
+            LocalDateTime startTime = LocalDateTime.ofInstant(jvmStartTime, ZoneId.systemDefault());
+            String startDateTime = startTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
 
-        Instant nowInstant = dto.service.timeNow;
-        LocalDateTime nowTime = LocalDateTime.ofInstant(nowInstant, ZoneId.systemDefault());
-        Duration runningTime = Duration.between(dto.service.runningSince, dto.service.timeNow);
-        String uptime = DurationFormatter.format(runningTime);
-        out.println("Time now:           " + nowTime.format(DateTimeFormatter.ISO_DATE_TIME));
-        out.println("Running since:      " + startDateTime + " (" + uptime + ")");
+            Instant nowInstant = dto.service.timeNow;
+            LocalDateTime nowTime = LocalDateTime.ofInstant(nowInstant, ZoneId.systemDefault());
+            Duration runningTime = Duration.between(dto.service.runningSince, dto.service.timeNow);
+            String uptime = DurationFormatter.format(runningTime);
+            out.println("Time now:           " + nowTime.format(DateTimeFormatter.ISO_DATE_TIME));
+            out.println("Running since:      " + startDateTime + " (" + uptime + ")");
+        }
+        else {
+            out.println("Service info excluded in this report");
+        }
+
         out.println("Data freshness:     " + (dto.synchronous
                 ? "Updated synchronous"
                 : "Retrieved from cache (Updates async in background threads)"));


### PR DESCRIPTION
Added option to CreateReportRequest to allow excluding service information, so we don't have to calculate it for requests that don't need it, such as readiness and liveness probes.